### PR TITLE
Fix issues in policy handling in wavsep scans

### DIFF
--- a/wavsep/wavsep-1.5-spider-scan.py
+++ b/wavsep/wavsep-1.5-spider-scan.py
@@ -14,7 +14,7 @@ def main(argv):
    policy = None
    
    try:
-      opts, args = getopt.getopt(argv,"haztp",["zap=","wavsep=","ajax","policy="])
+      opts, args = getopt.getopt(argv,"haz:w:p:",["zap=","wavsep=","ajax","policy="])
    except getopt.GetoptError:
       print 'test.py -z <ZAPipaddr> -w <WAVSEPipaddr>'
       sys.exit(2)
@@ -29,7 +29,7 @@ def main(argv):
       elif opt in ("-a", "--ajax"):
          ajax = True
       elif opt in ("-p", "--policy"):
-         ploicy = arg
+         policy = arg
    print 'zap is', zapHostIp
    print 'wavsep is ', wavsepHostIp
    

--- a/wavsep/zap-vs-wavsep-1.5.sh
+++ b/wavsep/zap-vs-wavsep-1.5.sh
@@ -19,7 +19,7 @@ USAGE="Usage: $0 [-a] -d docker-image [-e expected-score] -n name [-t text] [-z 
 docker=''
 expected=''
 name=''
-policy='Default policy'
+policy='Default Policy'
 text=''
 zap_opt=''
 score_opt=''
@@ -125,7 +125,7 @@ echo Let ZAP start up...
 sleep 20
 
 # Spider and scan the app
-python ~/zap-mgmt-scripts/wavsep/wavsep-1.5-spider-scan.py $score_opt -p $policy -z $ZPIP -w $WSIP >> ~/wrk/out.txt
+python ~/zap-mgmt-scripts/wavsep/wavsep-1.5-spider-scan.py $score_opt -p "$policy" -z $ZPIP -w $WSIP >> ~/wrk/out.txt
 
 # Save the logs
 LOG="~/zap-mgmt-scripts_gh-pages/reports/${name}.logs.txt"


### PR DESCRIPTION
Fix typo in variable ("policy") and set options with required arguments
("p", "w" and "z") in wavsep-1.5-spider-scan.py.
Change the case of the default policy name to match "Default Policy"
(since it's case sensitive in Linux) and quote the $policy variable when
passing as argument to Python script (because of the space character in
the default policy name) in zap-vs-wavsep-1.5.sh.

---
Issue reported in OWASP ZAP Developer Group: https://groups.google.com/d/msg/zaproxy-develop/kpxnenhuoJA/HYFfCyoJDAAJ