### PR TITLE
Show quality column only with weekly releases

### DIFF
--- a/wavsep/wavsep-score.py
+++ b/wavsep/wavsep-score.py
@@ -242,6 +242,7 @@ def main(argv):
 	alertOtherCount = {}
 
 	zapVersion = zap.core.version
+	devVersion = zapVersion.startswith("D")
 
 	totalAlerts = 0
 	offset = 0
@@ -518,7 +519,7 @@ def main(argv):
 	progress = zap.ascan.scan_progress()
 	# Loop through first time for the chart
 	for plugin in progress[1]['HostProcess']:
-		reportFile.write("      ['" + plugin['Plugin'][0] + "', " + plugin['Plugin'][3] + "],\n")
+		reportFile.write("      ['" + plugin['Plugin'][0] + "', " + plugin['Plugin'][4 if devVersion else 3] + "],\n")
 
 	# The end of the first chart
 	reportFile.write("    ]);\n")
@@ -538,7 +539,7 @@ def main(argv):
 
 	# Loop through 2nd time for the 2nd chart
 	for plugin in progress[1]['HostProcess']:
-		reportFile.write("      ['" + plugin['Plugin'][0] + "', " + plugin['Plugin'][4] + "],\n")
+		reportFile.write("      ['" + plugin['Plugin'][0] + "', " + plugin['Plugin'][5 if devVersion else 4] + "],\n")
 
 	# The end of the chart script
 	reportFile.write("    ]);\n")
@@ -556,7 +557,10 @@ def main(argv):
 	reportFile.write("<div id=\"chart_div2\" style=\"margin-left: 620px;\"></div>\n")
 
 	reportFile.write("<table border=\"1\">\n")
-	reportFile.write("<tr><th>Plugin</th><th>ms</th><th>Reqs</th><th>Quality</th></tr>\n")
+	reportFile.write("<tr><th>Plugin</th><th>ms</th><th>Reqs</th>")
+	if devVersion:
+		reportFile.write("<th>Quality</th>")
+	reportFile.write("</tr>\n")
 
 	# Loop through second time for the table
 	totalTime = 0
@@ -564,18 +568,22 @@ def main(argv):
 		reportFile.write("<tr>")
 		reportFile.write("<td>" + plugin['Plugin'][0] + "</td>")
 		# Convert ms into something more readable
-		t = int(plugin['Plugin'][4])
+		t = int(plugin['Plugin'][4 if devVersion else 3])
 		totalTime += t
 		s, ms = divmod(t, 1000)
 		m, s = divmod(s, 60)
 		h, m = divmod(m, 60)
 		time = "%d:%02d:%02d.%03d" % (h, m, s, ms)
 		reportFile.write("<td>" + time + "</td>")
-		reportFile.write("<td>" + plugin['Plugin'][5] + "</td>")
-		reportFile.write("<td>" + plugin['Plugin'][2] + "</td>")
+		reportFile.write("<td>" + plugin['Plugin'][5 if devVersion else 4] + "</td>")
+		if devVersion:
+			reportFile.write("<td>" + plugin['Plugin'][2] + "</td>")
 		reportFile.write("</tr>\n")
 
-	reportFile.write("<tr><td></td><td></td><td></td><td></td></tr>")
+	reportFile.write("<tr><td></td><td></td><td></td>")
+	if devVersion:
+		reportFile.write("<td></td>")
+	reportFile.write("</tr>")
 	reportFile.write("<tr>")
 	reportFile.write("<td>Total</td>")
 	# Convert ms into something more readable
@@ -584,7 +592,9 @@ def main(argv):
 	h, m = divmod(m, 60)
 	time = "%d:%02d:%02d" % (h, m, s)
 	reportFile.write("<td>" + time + "</td>")
-	reportFile.write("<td>-</td><td>-</td>")
+	reportFile.write("<td>-</td>")
+	if devVersion:
+		reportFile.write("<td>-</td>")
 	reportFile.write("</tr>\n")
 
 	reportFile.write("</table><br/>\n")


### PR DESCRIPTION
Change wavsep-score.py script to only show the quality column if the
scan was run with weekly releases, version 2.4.3 does not have that
information. Also, fix the charts for weekly releases (use new indexes).

Related to #5 - Fix wavsep script for latest weekly releases