### PR TITLE
Update tag used in add-on stats

### DIFF
--- a/count-addon-downloads.py
+++ b/count-addon-downloads.py
@@ -3,7 +3,7 @@
 
 import glob,json,os,sys
 
-TAG = '2.6'
+TAG = '2.7'
 
 # Number of days to chart
 days = 7


### PR DESCRIPTION
Change count-addon-downloads.py to use latest tag (2.7) to count the
latest released add-ons.