### PR TITLE
Update Docker weekly script for new dir location

### DIFF
--- a/docker-weekly.sh
+++ b/docker-weekly.sh
@@ -1,3 +1,3 @@
 cd ../zaproxy
-docker build --no-cache -t owasp/zap2docker-weekly -f build/docker/Dockerfile-weekly build/docker/
+docker build --no-cache -t owasp/zap2docker-weekly -f docker/Dockerfile-weekly docker/
 docker push owasp/zap2docker-weekly


### PR DESCRIPTION
Update the script `docker-weekly.sh` to use the new location, `docker`
instead of `build/docker`.

Part of zaproxy/zaproxy#4489 - Move docker dir to a top level dir