### PR TITLE
Disable Crowdin job

### DIFF
--- a/crontab.i18n
+++ b/crontab.i18n
@@ -1,4 +1,4 @@
-0 0 * * * cd /home/ubuntu/zap-mgmt-scripts;/usr/bin/git pull;./download-commit-update-i18n.sh
+# 0 0 * * * cd /home/ubuntu/zap-mgmt-scripts;/usr/bin/git pull;./download-commit-update-i18n.sh
 0 1 * * 0 cd /home/ubuntu/zap-mgmt-scripts;./commit-coverity.sh
 0 2 * * 0 cd /home/ubuntu/zap-mgmt-scripts/; tiptweets/rndtweettime.sh
 0 3 1 * * zap-admin/scripts/report_addons_to_release.sh


### PR DESCRIPTION
Disable until all issues are sorted out (e.g. escaped newline chars
being added to translations, relocation of source files for merge of
zap-extensions).