### PR TITLE
Update Docker link

### DIFF
--- a/tiptweets/tweets.txt
+++ b/tiptweets/tweets.txt
@@ -23,7 +23,7 @@ You can change the syntax highlighting used for the Request, Response and Script
 You can tell @zaproxy to load all of the scripts in a set of directories via the Scripts Option page. See the help for details
 You can export all of the URLs recorded by @zaproxy using the top level menu: "Report / Export All URLs to a File..."
 You can invoke 3rd party tools like sqlmap and nmap from within ZAP, passing across a wide range of contextual information
-Run @zaproxy using Docker : see https://github.com/zaproxy/zaproxy/wiki/Docker
+Run @zaproxy using Docker : see https://www.zaproxy.org/docs/docker/
 Install the beta active and passive scan rules to find more potential issues. There are also alpha active and passive rules
 You can script @zaproxy using python and ruby - download them from the Marketplace from within ZAP
 Install the SAML Add-on from the @zaproxy Marketplace to detect, show, edit and fuzz SAML requests


### PR DESCRIPTION
Link to the site instead of the wiki.
Migrated in zaproxy/zaproxy-website#103.