### PR TITLE
Add record-stats workflow

### DIFF
--- a/.github/workflows/record-stats.yml
+++ b/.github/workflows/record-stats.yml
@@ -1,0 +1,47 @@
+name: Update Download Stats
+
+on:
+  schedule:
+    - cron:  '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  record_stats:
+    name: Record Stats
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Build and push update
+      run: |
+        # Setup git details
+        export GITHUB_USER=zapbot
+        export GITHUB_TOKEN=${{ secrets.ZAPBOT_TOKEN }}
+        git config --global user.email "12745184+zapbot@users.noreply.github.com"
+        git config --global user.name $GITHUB_USER
+        git clone https://github.com/$GITHUB_USER/zap-mgmt-scripts.git
+        cp -R zap-mgmt-scripts/ master
+        cp -R zap-mgmt-scripts/ gh-pages
+        cd gh-pages
+        git checkout gh-pages
+        git remote set-url origin https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$GITHUB_USER/zap-mgmt-scripts.git
+        # Setup env vars for later
+        export PAGES_ROOT=$(pwd)
+        cd ../master
+        export MASTER_ROOT=$(pwd)
+        export DATE=$(date --rfc-3339 date)
+        # Record the download stats
+        curl https://api.github.com/repos/zaproxy/zaproxy/releases > $PAGES_ROOT/stats/releases-${DATE}.json
+        # Generate the ZAP download page
+        rm -f $PAGES_ROOT/downloads.html
+        cat $PAGES_ROOT/download.head > $PAGES_ROOT/downloads.html
+        cd $PAGES_ROOT
+        python $MASTER_ROOT/count-zap-downloads.py >> $PAGES_ROOT/downloads.html
+        cat $PAGES_ROOT/download.tail >> $PAGES_ROOT/downloads.html
+        # Push to the repo
+        cd $PAGES_ROOT
+        git add downloads.html stats date.txt
+        git commit -m "Stats for ${DATE}" --signoff
+        git push origin

--- a/count-zap-downloads.py
+++ b/count-zap-downloads.py
@@ -4,20 +4,20 @@
 import glob,json,os,sys
 
 # The file names
-REL = '2.7.0'
-CORE = 'ZAP_2.7.0_Core.tar.gz'
-CROSS = 'ZAP_2.7.0_Crossplatform.zip'
-LINUX = 'ZAP_2.7.0_Linux.tar.gz'
-UNIX = 'ZAP_2_7_0_unix.sh'
-MAC = 'ZAP_2.7.0.dmg'
-WIN32 = 'ZAP_2_7_0_windows-x32.exe'
-WIN64 = 'ZAP_2_7_0_windows.exe'
+REL = 'v2.9.0'
+CORE = 'ZAP_2.9.0_Core.zip'
+CROSS = 'ZAP_2.9.0_Crossplatform.zip'
+LINUX = 'ZAP_2.9.0_Linux.tar.gz'
+UNIX = 'ZAP_2_9_0_unix.sh'
+MAC = 'ZAP_2.9.0.dmg'
+WIN32 = 'ZAP_2_9_0_windows-x32.exe'
+WIN64 = 'ZAP_2_9_0_windows.exe'
 
 counts = {}
-files = sorted(glob.glob('../zap-mgmt-scripts_gh-pages/stats/releases-*'))
+files = sorted(glob.glob('./stats/releases-*'))
 # Option to just show the last 180 days to prevent the chart getting too big
 files = files[-180:]
-# Change to 1 once 2.7.0 has been out for more than 180 days ;)
+# Change to 1 once 2.9.0 has been out for more than 180 days ;)
 first = 0
 for file in files:
   with open(file) as stats_file:


### PR DESCRIPTION
- recoard-stats.yml > New workflow that runs daily at midnight updating the ZAP download stats page.
- count-zap-downloads.py > Minor modifications to work in the new workflow.

NOTE: This does not yet include add-on stats as their handling has changed significantly since last use. Additionally record-stats.sh
hasn't been removed yet so that it can easily be a recerence for the add-on bit.

NOTE 2: I've submitted another PR to update `download.head` and `download.tail` for 2.9.0 and current state. (See https://github.com/zapbot/zap-mgmt-scripts/pull/26)

https://github.com/kingthorin/zap-mgmt-scripts/tree/gh-pages is based on a test run https://github.com/kingthorin/zap-mgmt-scripts/runs/895709564?check_suite_focus=true. I'll have to reset it after this is merged.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>