### PR TITLE
Fix ZAP Download Counts Job

### DIFF
--- a/.github/workflows/record-stats.yml
+++ b/.github/workflows/record-stats.yml
@@ -35,7 +35,7 @@ jobs:
         export MASTER_ROOT=$(pwd)
         export DATE=$(date --rfc-3339 date)
         # Record the download stats
-        curl https://api.github.com/repos/zaproxy/zaproxy/releases/tags/$TAG > $PAGES_ROOT/stats/releases-${DATE}.json
+        curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 --retry-connrefused https://api.github.com/repos/zaproxy/zaproxy/releases/tags/$TAG > $PAGES_ROOT/stats/releases-${DATE}.json
         # Generate the ZAP download page
         rm -f $PAGES_ROOT/downloads.html
         cat $PAGES_ROOT/download.head > $PAGES_ROOT/downloads.html

--- a/.github/workflows/record-stats.yml
+++ b/.github/workflows/record-stats.yml
@@ -15,6 +15,8 @@ jobs:
       with:
         python-version: '3.x'
     - name: Build and push update
+      env:
+        TAG: v2.9.0
       run: |
         # Setup git details
         export GITHUB_USER=zapbot
@@ -33,7 +35,7 @@ jobs:
         export MASTER_ROOT=$(pwd)
         export DATE=$(date --rfc-3339 date)
         # Record the download stats
-        curl https://api.github.com/repos/zaproxy/zaproxy/releases > $PAGES_ROOT/stats/releases-${DATE}.json
+        curl https://api.github.com/repos/zaproxy/zaproxy/releases/tags/$TAG > $PAGES_ROOT/stats/releases-${DATE}.json
         # Generate the ZAP download page
         rm -f $PAGES_ROOT/downloads.html
         cat $PAGES_ROOT/download.head > $PAGES_ROOT/downloads.html

--- a/count-zap-downloads.py
+++ b/count-zap-downloads.py
@@ -21,21 +21,20 @@ for file in files:
   with open(file) as stats_file:
     stats = json.load(stats_file)
 
-  for stat in stats:
-    if (stat['name'] == REL):
-      assets = {}
-      for asset in stat['assets']:
-        name = asset['name']
-        count = asset['download_count']
-        if (name in counts):
-          # Ignore negative numbers - can happen when files are replaced
-          assets[name] = max((count - counts[name]), 0)
-        else:
-          assets[name] = count
-        counts[name] = count
-      if (files.index(file) == 0):
-        # Ignore the first as its just for getting a baseline
-        continue
+  if (stats['name'] == REL):
+    assets = {}
+    for asset in stats['assets']:
+      name = asset['name']
+      count = asset['download_count']
+      if (name in counts):
+        # Ignore negative numbers - can happen when files are replaced
+        assets[name] = max((count - counts[name]), 0)
       else:
-        print("        ['%s', %d, %d, %d, %d, %d, %d, %d, '']," % (file[-15:-5], 
-          assets[WIN64], assets[WIN32], assets[UNIX], assets[LINUX], assets[MAC], assets[CROSS], assets[CORE]))
+        assets[name] = count
+      counts[name] = count
+    if (files.index(file) == 0):
+      # Ignore the first as its just for getting a baseline
+      continue
+    else:
+      print("        ['%s', %d, %d, %d, %d, %d, %d, %d, '']," % (file[-15:-5], 
+        assets[WIN64], assets[WIN32], assets[UNIX], assets[LINUX], assets[MAC], assets[CROSS], assets[CORE]))


### PR DESCRIPTION
- record-stats.yml > Get the specific tag instead of all releases.
- count-zap-downloads.py > Only one release in the file so no longer needs to loop.

Fixes zapbot/zap-mgmt-scripts#33

---

Also: Add curl retry switches, because of: 
- https://github.com/zapbot/zap-mgmt-scripts/runs/1046376589?check_suite_focus=true

Per:
- https://curl.haxx.se/docs/manpage.html
- https://stackoverflow.com/questions/42873285/curl-retry-mechanism

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>