### PR TITLE
New stats collection

### DIFF
--- a/.github/workflows/record-stats-v2.yml
+++ b/.github/workflows/record-stats-v2.yml
@@ -1,0 +1,74 @@
+name: Collect Daily Stats
+
+on:
+  schedule:
+    - cron:  '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  record_stats:
+    name: Collect Daily Stats
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Set up env
+      run: |
+        python -m pip install requests
+
+        # Set up AWS CLI
+        export AWSCLI_ACCESS=${{ secrets.AWSCLI_ACCESS }}
+        export AWSCLI_SECRET=${{ secrets.AWSCLI_SECRET }}
+        python -m pip install awscli
+        mkdir ~/.aws
+        echo "[default]" > ~/.aws/config
+        echo "[default]" > ~/.aws/credentials
+        echo "aws_access_key_id = $AWSCLI_ACCESS" >> ~/.aws/credentials
+        echo "aws_secret_access_key = $AWSCLI_SECRET" >> ~/.aws/credentials
+        
+        # Setup git details
+        export GITHUB_USER=zapbot
+        export GITHUB_TOKEN=${{ secrets.ZAPBOT_TOKEN }}
+        git config --global user.email "12745184+zapbot@users.noreply.github.com"
+        git config --global user.name $GITHUB_USER
+
+    - name: Clone zap-mgmt-scripts
+      run: |
+        git clone https://github.com/$GITHUB_USER/zap-mgmt-scripts.git
+
+        cp -R zap-mgmt-scripts/ master
+        cp -R zap-mgmt-scripts/ gh-pages
+        cd gh-pages
+        git checkout gh-pages
+        git remote set-url origin https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$GITHUB_USER/zap-mgmt-scripts.git
+        cd ..
+    - name: Sync S3 files
+      run: |
+        mkdir project-zap
+        mkdir project-zap/stats
+        # This will gradually take longer and longer so at some point we could limit it to just recent files
+        aws s3 sync s3://project-zap/stats/ project-zap/stats/
+        
+    - name: Collect todays stats
+      run: |
+        export BITLY_TOKEN=${{ secrets.BITLY_TOKEN }}
+
+        cd master/stats
+        python3 stats.py collect
+        
+        # TODO raise an issue if not empty
+        echo "Any errors?"
+        cat errors.txt
+        cd ../..
+
+    - name: Daily post process
+      run: |
+        cd master/stats
+        python3 stats.py daily
+        cd ../..
+
+    - name: Update S3 files
+      run: |
+        aws s3 sync project-zap/stats/ s3://project-zap/stats/ 

--- a/stats/bitly.py
+++ b/stats/bitly.py
@@ -1,0 +1,82 @@
+'''
+Script for collecting and processing the ZAP bitly stats
+'''
+import glob
+import json
+import os
+import sys
+import utils
+
+links = [
+    "owaspzap-2-9-0d", \
+    "owaspzap-2-9-0", \
+    "owaspzap-2-8-0", \
+    "owaspzap-2-7-0", \
+    "owaspzap-2-6-0", \
+    "owaspzap-2-5-0", \
+    "owaspzap-2-4-3", \
+    "owaspzap-devw", \
+    "owaspzap-news-2-9", \
+    "owaspzap-news-2-8", \
+    "owaspzap-news-dev", \
+    "owaspzap-hud", \
+    "owaspzap-hud-tutorial-start", \
+    "owaspzap-hud-tutorial-end", \
+    "owaspzap-start-2-7", \
+    "owaspzap-start-2-6", \
+    "owaspzap-start-dev", \
+    ]
+
+bitly_api = "https://api-ssl.bitly.com/v4/bitlinks/bit.ly/{{LINK}}/clicks?unit=day&units=-1&size=7"
+
+def collect():
+    headers = {'Authorization': 'Bearer ' + os.getenv('BITLY_TOKEN')}
+    for link in links:
+        utils.download_to_file(bitly_api.replace('{{LINK}}', link), utils.basedir() + "bitly/raw/" + utils.today() + '-' + link + ".json", headers)
+
+def daily():
+    files = sorted(glob.glob(utils.basedir() + 'bitly/raw/*.json'))
+    created = set()
+    first_month = ""
+    last_monthly_totals = {}
+    monthly_files_to_write = set()
+    for file in files:
+        with open(file) as stats_file:
+            stats = json.load(stats_file)
+            link = os.path.basename(stats_file.name)[20:-5]
+            date_collected = os.path.basename(stats_file.name)[:10]
+            #print(stats_file.name + ' ' + link + ' ' + date_collected)
+            for lc in stats['link_clicks']:
+                date_str = lc['date'][:10]
+                is_monthly = date_str.endswith('-01')
+                if is_monthly:
+                    if len(first_month) == 0:
+                        first_month = date_str
+                    if len(first_month) > 0 and not first_month == date_str:
+                        monthly_file = utils.basedir() + 'bitly/monthly/' + date_str + '.csv'
+                        if not os.path.exists(monthly_file):
+                            with open(monthly_file, "a") as f:
+                                f.write('date,link,clicks\n')
+                                monthly_files_to_write.add(date_str)
+                                print('Created ' + monthly_file)
+                        if date_str in monthly_files_to_write:
+                            with open(monthly_file, "a") as f:
+                                f.write(date_str + ',' + link + ',' + str(last_monthly_totals[link]) + '\n')
+                                last_monthly_totals[link] = 0
+
+                # Stats for the day of collection will probably be incomplete
+                if not date_str == date_collected:
+                    daily_file = utils.basedir() + 'bitly/daily/' + date_str + '.csv'
+                    if not os.path.exists(daily_file):
+                        with open(daily_file, "a") as f:
+                            f.write('date,link,clicks\n')
+                        created.add(date_str)
+                        print('Created ' + daily_file)
+                    if date_str in created:
+                        with open(daily_file, "a") as f:
+                            f.write(date_str + ',' + link + ',' + str(lc['clicks']) + '\n')
+
+                    # Monthly totals
+                    if not link in last_monthly_totals:
+                        last_monthly_totals[link] = 0
+                    last_monthly_totals[link] += lc['clicks']

--- a/stats/docker.py
+++ b/stats/docker.py
@@ -1,0 +1,58 @@
+'''
+Script for collecting and processing the ZAP docker stats
+'''
+import glob
+import json
+import os
+import utils
+
+urls = {
+    "stable": "https://registry.hub.docker.com/v2/repositories/owasp/zap2docker-stable/",
+    "weekly": "https://registry.hub.docker.com/v2/repositories/owasp/zap2docker-weekly/",
+    "live": "https://registry.hub.docker.com/v2/repositories/owasp/zap2docker-live/",
+    "bare": "https://registry.hub.docker.com/v2/repositories/owasp/zap2docker-bare/",
+    }
+
+def collect():
+    for key, url in urls.items():
+        utils.download_to_file(url, utils.basedir() + "docker/raw/" + utils.today() + '-' + key + ".json")
+
+def daily():
+    files = sorted(glob.glob(utils.basedir() + 'docker/raw/*.json'))
+    created = set()
+    last_monthly_totals = {}
+    last_day_totals = {}
+    monthly_files_to_write = set()
+    for file in files:
+        with open(file) as stats_file:
+            stats = json.load(stats_file)
+            link = os.path.basename(stats_file.name)[20:-5]
+            date_str = os.path.basename(stats_file.name)[:10]
+            image = stats['name']
+            total = stats['pull_count']
+
+            is_monthly = date_str.endswith('-01')
+            if is_monthly:
+                if image in last_monthly_totals:
+                    monthly_file = utils.basedir() + 'docker/monthly/' + date_str + '.csv'
+                    if not os.path.exists(monthly_file):
+                        with open(monthly_file, "a") as f:
+                            f.write('date,image,total,increase,stars\n')
+                            monthly_files_to_write.add(date_str)
+                            print('Created ' + monthly_file)
+                    if date_str in monthly_files_to_write:
+                        with open(monthly_file, "a") as f:
+                            f.write(date_str + ',' + image + ',' + str(total) + ',' + str(total - last_monthly_totals[image]) + ',' + str(stats['star_count']) + "\n")
+                last_monthly_totals[image] = total
+
+            if image in last_day_totals:
+                daily_file = utils.basedir() + 'docker/daily/' + date_str + '.csv'
+                if not os.path.exists(daily_file):
+                    with open(daily_file, "a") as f:
+                        f.write('date,image,total,increase,stars\n')
+                    created.add(date_str)
+                    print('Created ' + daily_file)
+                if date_str in created:
+                    with open(daily_file, "a") as f:
+                        f.write(date_str + ',' + image + ',' + str(total) + ',' + str(total - last_day_totals[image]) + ',' + str(stats['star_count']) + "\n")
+            last_day_totals[image] = total

--- a/stats/github.py
+++ b/stats/github.py
@@ -1,0 +1,96 @@
+'''
+Script for collecting and processing the ZAP github stats
+'''
+import utils
+import glob
+import json
+import os
+import sys
+
+tags = [
+    "v2.9.0",
+    "v2.8.0",
+    ]
+
+mappings = {
+  "core": "core",
+  "crossplatform": "cross",
+  "linux": "linux",
+  "unix": "unix",
+  "deb": "deb",
+  "dmg": "mac",
+  "windows-x32": "win32",
+  "windows.exe": "win64",
+}
+
+github_api = "https://api.github.com/repos/zaproxy/zaproxy/releases/tags/"
+
+def collect():
+    for tag in tags:
+        utils.download_to_file(github_api + tag, utils.basedir() + "downloads/raw/" + utils.today() + '-' + tag + ".json")
+
+def daily():
+    # Process the download stats
+    counts = {}
+    assets = {}
+    daily_files_to_write = set()
+    monthly_files_to_write = set()
+    files = sorted(glob.glob(utils.basedir() + "downloads/raw/*.json"))
+    last_monthly_totals = {}
+    for file in files:
+        with open(file) as stats_file:
+            stats = json.load(stats_file)
+            date_str = os.path.basename(stats_file.name)[:10]
+            daily_file = utils.basedir() + 'downloads/daily/' + date_str + '.csv'
+            # Todays stats will be incomplete as this is run at the start of the day
+            if not os.path.exists(daily_file) and not date_str == utils.today():
+                daily_files_to_write.add(date_str)
+                with open(daily_file, "a") as f:
+                    print('Creating ' + daily_file)
+                    f.write('date,version,name,tag,downloads\n')
+                    
+            is_monthly = date_str.endswith('-01')
+            daily_total = 0
+            for asset in stats['assets']:
+                tag = stats['name']
+                name = asset['name']
+                count = asset['download_count']
+                if (name in counts):
+                    # Ignore negative numbers - can happen when files are replaced
+                    old_count = counts[name]
+                else:
+                    old_count = 0
+                if (name in counts):
+                    # Ignore negative numbers - can happen when files are replaced
+                    assets[name] = max((count - counts[name]), 0)
+                else:
+                    assets[name] = count
+                counts[name] = count
+                if is_monthly:
+                    daily_total += counts[name]
+                mapping = "Unknown"
+                for m in mappings:
+                    if m in name.lower():
+                        mapping = mappings[m]
+                        break
+                
+                if old_count > 0:
+                    # There can be multiple raw files with the same date, ie one per tag
+                    if date_str in daily_files_to_write:
+                        with open(daily_file, "a") as f:
+                            f.write(date_str + ',' +  tag + ',' + asset['name'] + ',' + mapping + ',' + str(assets[name]) + '\n')
+
+            if is_monthly:
+                if tag in last_monthly_totals:
+                    monthly_file = utils.basedir() + 'downloads/monthly/' + date_str + '.csv'
+                    if not os.path.exists(monthly_file):
+                        monthly_files_to_write.add(date_str)
+                        with open(monthly_file, "a") as f:
+                            print('Creating ' + monthly_file)
+                            f.write('date,version,total,downloads\n')
+                    # There can be multiple raw files with the same date, ie one per tag
+                    if date_str in monthly_files_to_write:
+                        with open(monthly_file, "a") as f:
+                            f.write(date_str + ',' +  tag + ',' + str(daily_total) + ',' + str(daily_total - last_monthly_totals[tag]))
+
+                last_monthly_totals[tag] = daily_total

--- a/stats/stats.py
+++ b/stats/stats.py
@@ -1,0 +1,31 @@
+# Local files which handle specific stats
+import docker
+import github
+import bitly
+
+# Python imports
+import os
+import sys
+
+def usage():
+    print("stats.py collect | daily | monthly")
+
+def collect():
+    docker.collect()
+    github.collect()
+    bitly.collect()
+
+def daily():
+    docker.daily()
+    github.daily()
+    bitly.daily()
+
+if __name__ == '__main__':
+    if len(sys.argv) == 2:
+        fn = sys.argv[1]
+        if fn in globals():
+            globals()[sys.argv[1]]()
+        else:
+            usage()
+    else:
+        usage()

--- a/stats/utils.py
+++ b/stats/utils.py
@@ -1,0 +1,30 @@
+import logging
+from requests import get
+from datetime import datetime
+
+def today():
+    return datetime.today().strftime('%Y-%m-%d')
+
+def basedir():
+    return "../../project-zap/stats/"
+
+def download_to_file(url, filename, headers={}):
+    errors = open("errors.txt", 'a')
+
+    with open(filename, "wb") as file:
+        try:
+            print("Downloading " + url)
+            response = get(url, headers=headers)
+            if response.status_code == 200:
+                file.write(response.content)
+            else:
+                print("Failed to download " + url)
+                errors.write("Failed accessing " + url + " status code: " + str(response.status_code))
+                errors.write("\n\n")
+        except Exception as x:
+            print("Failed to download " + url)
+            errors.write("Failed accessing " + url + "\n")
+            errors.write(logging.traceback.format_exc())
+            errors.write("\n\n")
+
+    errors.close()


### PR DESCRIPTION
The collect functions all seem to work: https://github.com/psiinon/zap-mgmt-scripts/runs/1296920608?check_suite_focus=true

The github 'daily' function also seems to work based on local testing, the docker and bitly ones are still to do.

I've added the right secrets so that the new action runs successfully in my fork. This means that we'll start collecting the daily stats.
When it passes review and merged then I'll delete them and put them in this repo.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>