### PR TITLE
Fix ZAP service stats

### DIFF
--- a/.github/workflows/record-zap-service-stats.yml
+++ b/.github/workflows/record-zap-service-stats.yml
@@ -1,0 +1,76 @@
+name: Collect Daily ZAP Service Stats - temp test action
+
+on:
+  schedule:
+    - cron:  '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  record_stats:
+    name: Collect Daily ZAP Service Stats - temp test action
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Set up env
+      run: |
+        python -m pip install requests
+
+        # Set up AWS CLI
+        export AWSCLI_ACCESS=${{ secrets.AWSCLI_ACCESS }}
+        export AWSCLI_SECRET=${{ secrets.AWSCLI_SECRET }}
+        python -m pip install awscli
+        mkdir ~/.aws
+        echo "[default]" > ~/.aws/config
+        echo "region = us-east-2" >> ~/.aws/config
+        echo "[default]" > ~/.aws/credentials
+        echo "aws_access_key_id = $AWSCLI_ACCESS" >> ~/.aws/credentials
+        echo "aws_secret_access_key = $AWSCLI_SECRET" >> ~/.aws/credentials
+
+    - name: Clone zap-mgmt-scripts
+      run: |
+        # Setup git details
+        export GITHUB_USER=zapbot
+        export GITHUB_TOKEN=${{ secrets.ZAPBOT_TOKEN }}
+        git config --global user.email "12745184+zapbot@users.noreply.github.com"
+        git config --global user.name $GITHUB_USER
+        git clone https://github.com/$GITHUB_USER/zap-mgmt-scripts.git
+
+        cp -R zap-mgmt-scripts/ master
+        cp -R zap-mgmt-scripts/ gh-pages
+        cd gh-pages
+        git checkout gh-pages
+        git remote set-url origin https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$GITHUB_USER/zap-mgmt-scripts.git
+        cd ..
+
+    - name: Sync S3 files
+      run: |
+        mkdir project-zap
+        mkdir project-zap/stats
+        # This will gradually take longer and longer so at some point we could limit it to just recent files
+        aws s3 sync s3://project-zap/stats/ project-zap/stats/
+        
+    - name: Collect todays stats
+      run: |
+        export BITLY_TOKEN=${{ secrets.BITLY_TOKEN }}
+
+        cd master/stats
+        python3 zap_services.py collect
+        
+        # TODO raise an issue if not empty
+        echo "Any errors?"
+        cat errors.txt
+        cd ../..
+
+    - name: Daily post process
+      run: |
+        cd master/stats
+        python3 zap_services.py daily
+        cd ../..
+
+    - name: Update S3 files
+      run: |
+        aws s3 sync project-zap/stats/ s3://project-zap/stats/ 

--- a/stats/zap_services.py
+++ b/stats/zap_services.py
@@ -80,14 +80,14 @@ def copy_without_quotes(source, dest) :
 def collect():
     # Requests by day and version
     aws_athena_query_to_file(
-        'SELECT day, zapVersion, count(*) FROM "zap_cfu"."default"."zap-cfu" WHERE day = \'' + today_str + '\' GROUP BY day, zapVersion', 
+        'SELECT day, zapVersion, count(*) as count FROM "zap-cfu-DS"."default"."zap-cfu" WHERE day = \'' + today_str + '\' GROUP BY day, zapVersion', 
         day_raw_file)
     
     # Requests by month and version
     if not os.path.isfile(mon_raw_file):
         # For historical reasons the monthly stats are collected on the 2nd of the next month
         aws_athena_query_to_file(
-            'SELECT \'' + this_mon_str + '-02\', zapVersion, count(*) FROM "zap_cfu"."default"."zap-cfu" WHERE day LIKE \'' + last_mon_str + '-%\' GROUP BY zapVersion', 
+            'SELECT \'' + this_mon_str + '-02\', zapVersion, count(*) as count FROM "zap-cfu-DS"."default"."zap-cfu" WHERE day LIKE \'' + last_mon_str + '-%\' GROUP BY zapVersion', 
             mon_raw_file)
     
 
@@ -105,3 +105,8 @@ def website():
     # All handled by the bitly script
     pass
 
+if __name__ == '__main__':
+    if len(sys.argv) == 2:
+        fn = sys.argv[1]
+        if fn in globals():
+            globals()[sys.argv[1]]()


### PR DESCRIPTION
The Athena Data Source name has changed.
I've created a new temp action for just collecting the ZAP service stats so that the std stats job doesnt break again...
Once this is working the service stats can be re-enabled and the temp job deleted.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>