### PR TITLE
Tweak temp action

### DIFF
--- a/.github/workflows/record-zap-service-stats.yml
+++ b/.github/workflows/record-zap-service-stats.yml
@@ -60,9 +60,6 @@ jobs:
         cd master/stats
         python3 zap_services.py collect
         
-        # TODO raise an issue if not empty
-        echo "Any errors?"
-        cat errors.txt
         cd ../..
 
     - name: Daily post process


### PR DESCRIPTION
The ZAP service script doesnt write to error.txt so that failed :P

Signed-off-by: Simon Bennetts <psiinon@gmail.com>