### PR TITLE
Sync the CFU and News stats

### DIFF
--- a/.github/workflows/sync-stats.yml
+++ b/.github/workflows/sync-stats.yml
@@ -1,0 +1,32 @@
+name: Sync the CFU and News Stats
+
+on:
+  schedule:
+    - cron:  '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  record_stats:
+    name: Sync the CFU and News  Stats
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Sync the Stats
+      run: |
+        python -m pip install requests
+        # Set up AWS CLI
+        export AWSCLI_ACCESS=${{ secrets.AWSCLI_ACCESS }}
+        export AWSCLI_SECRET=${{ secrets.AWSCLI_SECRET }}
+        python -m pip install awscli
+        mkdir ~/.aws
+        echo "[default]" > ~/.aws/config
+        echo "region = us-east-2" >> ~/.aws/config
+        echo "[default]" > ~/.aws/credentials
+        echo "aws_access_key_id = $AWSCLI_ACCESS" >> ~/.aws/credentials
+        echo "aws_secret_access_key = $AWSCLI_SECRET" >> ~/.aws/credentials
+
+        aws s3 sync s3://project-zap-news/ s3://project-zap/stats/zap-news-test1/
+        aws s3 sync s3://project-zap-cfu/ s3://project-zap/stats/zap-cfu-test1/


### PR DESCRIPTION
This is only needed until the main S3 buckets are configured to be accessible in Athena.

I've been running those aws cli command manually, and got bored doing so ;)

Signed-off-by: Simon Bennetts <psiinon@gmail.com>