### PR TITLE
Move the stats

### DIFF
--- a/.github/workflows/sync-stats.yml
+++ b/.github/workflows/sync-stats.yml
@@ -1,4 +1,4 @@
-name: Sync the CFU and News Stats
+name: Sync the ZAP Service Stats
 
 on:
   schedule:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   record_stats:
-    name: Sync the CFU and News  Stats
+    name: Sync the ZAP Service Stats
     runs-on: ubuntu-latest
     steps:
     - name: Setup Python
@@ -28,5 +28,6 @@ jobs:
         echo "aws_access_key_id = $AWSCLI_ACCESS" >> ~/.aws/credentials
         echo "aws_secret_access_key = $AWSCLI_SECRET" >> ~/.aws/credentials
 
-        aws s3 sync s3://project-zap-news/ s3://project-zap/stats/zap-news-test1/
-        aws s3 sync s3://project-zap-cfu/ s3://project-zap/stats/zap-cfu-test1/
+        aws s3 mv s3://project-zap-news/ s3://project-zap/stats/zap-news/ --recursive
+        aws s3 mv s3://project-zap-cfu/ s3://project-zap/stats/zap-cfu/ --recursive
+        aws s3 mv s3://project-zap-tel/ s3://project-zap/telemetry/raw/ --recursive


### PR DESCRIPTION
Change to move the stats rather than syncing them.
The sync was a test - this is now the 'final' plan, hence the directory name changes.
I'll tidy up the old buckets when I'm happy its all working correctly.
Also moving the telemetry data now as well.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>