### PR TITLE
ZAP vs FR - another git tweak

### DIFF
--- a/.github/workflows/zap-vs-firingrange.yml
+++ b/.github/workflows/zap-vs-firingrange.yml
@@ -27,7 +27,7 @@ jobs:
         git checkout -B firingrange
         git pull upstream master
         git reset --hard upstream/master
-        git push origin --force
+        git push --set-upstream origin firingrange --force
 
     - name: Scan Firing Range
       run: |


### PR DESCRIPTION
https://github.com/zapbot/zap-mgmt-scripts/runs/5405181830?check_suite_focus=true
```
fatal: The current branch firingrange has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin firingrange
```

Signed-off-by: Simon Bennetts <psiinon@gmail.com>