### PR TITLE
Remove workaround from actions

### DIFF
--- a/.github/workflows/postprocess_telemetry.yml
+++ b/.github/workflows/postprocess_telemetry.yml
@@ -25,7 +25,6 @@ jobs:
 
     - name: Sync the Stats
       run: |
-        python -m pip install pyyaml==5.3.1
         python -m pip install requests
         # Set up AWS CLI
         export AWSCLI_ACCESS=${{ secrets.AWSCLI_ACCESS }}

--- a/.github/workflows/record-stats-v2.yml
+++ b/.github/workflows/record-stats-v2.yml
@@ -17,7 +17,6 @@ jobs:
 
     - name: Set up env
       run: |
-        python -m pip install pyyaml==5.3.1
         python -m pip install requests
 
         # Set up AWS CLI

--- a/.github/workflows/record-zap-service-stats.yml
+++ b/.github/workflows/record-zap-service-stats.yml
@@ -17,7 +17,6 @@ jobs:
 
     - name: Set up env
       run: |
-        python -m pip install pyyaml==5.3.1
         python -m pip install requests
 
         # Set up AWS CLI

--- a/.github/workflows/sync-stats.yml
+++ b/.github/workflows/sync-stats.yml
@@ -16,7 +16,6 @@ jobs:
         python-version: '3.x'
     - name: Sync the Stats
       run: |
-        python -m pip install pyyaml==5.3.1
         python -m pip install requests
         # Set up AWS CLI
         export AWSCLI_ACCESS=${{ secrets.AWSCLI_ACCESS }}

--- a/.github/workflows/update-website-stats.yml
+++ b/.github/workflows/update-website-stats.yml
@@ -18,7 +18,6 @@ jobs:
 
     - name: Set up env
       run: |
-        python -m pip install pyyaml==5.3.1
         python -m pip install requests
         python -m pip install awscli
 


### PR DESCRIPTION
A new version of aws-cli has been released that should no longer have the installation issue.