### PR TITLE
Remove Docker weekly script

### DIFF
--- a/docker-weekly.sh
+++ b/docker-weekly.sh
@@ -1,3 +1,0 @@
-cd ../zaproxy
-docker build --no-cache -t owasp/zap2docker-weekly -f docker/Dockerfile-weekly docker/
-docker push owasp/zap2docker-weekly


### PR DESCRIPTION
The Docker weekly image is built/pushed using a workflow in the main repo.

Ref zaproxy/zaproxy#6103.