### PR TITLE
Reduce crawler scans frequency

### DIFF
--- a/.github/workflows/zap-vs-crawlmaze.yml
+++ b/.github/workflows/zap-vs-crawlmaze.yml
@@ -2,7 +2,7 @@ name: ZAP vs Crawl Maze
 
 on: 
   schedule:
-    - cron:  '0 3 * * *' # 3 am every day
+    - cron:  '0 3 * * 1' # 3 am every Monday
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/zap-vs-juiceshop.yml
+++ b/.github/workflows/zap-vs-juiceshop.yml
@@ -2,7 +2,7 @@ name: ZAP vs Juice Shop
 
 on: 
   schedule:
-    - cron:  '30 3 * * *' # 3:30 am every day
+    - cron:  '30 3 * * 1' # 3:30 am every Monday
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Run just every Monday instead of daily, the AJAX Spider has too much variation in the paths found that leads to daily updates (PRs) to the test results.