### PR TITLE
Use newer Python ZAP API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The current instance being used is a t2.medium running with Ubuntu trusty and 24
 From a bare bones install, as root run:
 * apt-get update -y
 * apt-get -y install python-pip
-* pip install python-owasp-zap-v2.4
+* pip install zaproxy
 * pip install awscli
 * curl -sSL https://get.docker.com/ | sh
 * usermod -aG docker ubuntu

--- a/dockerfile
+++ b/dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get install -q -y --fix-missing curl git python3-pip
 
-RUN pip3 install --upgrade python-owasp-zap-v2.4
+RUN pip3 install --upgrade zaproxy
 
 WORKDIR /zap
 


### PR DESCRIPTION
Install `zaproxy` instead of `python-owasp-zap-v2.4`, the latter was renamed to the former.
Update instructions to mention the new package.