### PR TITLE
Crawlmaze scan, no longer create profile

### DIFF
--- a/.github/workflows/zap-vs-crawlmaze.yml
+++ b/.github/workflows/zap-vs-crawlmaze.yml
@@ -41,14 +41,11 @@ jobs:
         
         docker run -v $(pwd):/zap/wrk/:rw \
           -t ghcr.io/zaproxy/zaproxy:nightly sh -c \
-            "mkdir -p /home/zap/.mozilla/firefox/abc5jhgf.zap-client-profile/; \
-            echo '[Profile0]' >> /home/zap/.mozilla/firefox/profiles.ini; \
-            echo 'Name=zap-client-profile' >> /home/zap/.mozilla/firefox/profiles.ini; \
-            echo 'IsRelative=1' >> /home/zap/.mozilla/firefox/profiles.ini; \
-            echo 'Path=abc5jhgf.zap-client-profile' >> /home/zap/.mozilla/firefox/profiles.ini; \
-            ./zap.sh -cmd -silent -addoninstall client -autorun /zap/wrk/crawl-maze.yaml; \
-            cp /home/zap/.ZAP_D/zap.log /zap/wrk;"
+            "./zap.sh -cmd -silent -addoninstall client -autorun /zap/wrk/crawl-maze.yaml; \
+            cp /home/zap/.ZAP_D/zap.log /zap/wrk; \
+            ls -l /zap/wrk;"
         cp all.yml ../../../zaproxy-website/site/data/scans/crawlmaze/
+        ls -l
 
     - name: 'Upload zap.log'
       if: ${{ !cancelled() }}


### PR DESCRIPTION
Should no longer be needed, but added a couple more statements to try to work out why the zap.log file is not being uploaded..