### PR TITLE
Wait more for OWASP Benchmark to start

### DIFF
--- a/.github/workflows/zap-vs-owasp-benchmark.yml
+++ b/.github/workflows/zap-vs-owasp-benchmark.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Wait for the Benchmark service to be available
         run: |
-          curl -k --head --retry 12 --retry-all-errors --retry-delay 5 https://localhost:8443/benchmark
+          curl -k --head --retry 12 --retry-all-errors --retry-delay 30 https://localhost:8443/benchmark
 
       - name: Clone zap-mgmt-scripts and zaproxy-website
         run: |


### PR DESCRIPTION
The latest Docker image is now only linux/arm64 which, running with emulation, is slower to start.