### PR TITLE
Reenable ZAP vs OWASP Benchmark

### DIFF
--- a/.github/workflows/zap-vs-owasp-benchmark.yml
+++ b/.github/workflows/zap-vs-owasp-benchmark.yml
@@ -1,9 +1,8 @@
 name: ZAP vs OWASP Benchmark
 
 on:
-  # https://github.com/OWASP-Benchmark/BenchmarkJava/issues/223
-  #schedule:
-  #  - cron: "0 6 * * *" # 6 am every day
+  schedule:
+    - cron: "0 6 * * *" # 6 am every day
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The latest image published uses the expected arch.