### PR TITLE
Update zap-vs-crawlmaze.yml use  actions/upload-artifact v4

### DIFF
--- a/.github/workflows/zap-vs-crawlmaze.yml
+++ b/.github/workflows/zap-vs-crawlmaze.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: 'Upload zap.log'
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: zap.log
         path: ./zap.log


### PR DESCRIPTION
Address upcoming GHA deprecation:
![image](https://github.com/user-attachments/assets/32abae5b-a60a-415f-9ba1-6041a034eec3)
