### PR TITLE
Address concurrency issue with variant.js script

### DIFF
--- a/scans/benchmark/cmdi/variant.js
+++ b/scans/benchmark/cmdi/variant.js
@@ -2,6 +2,8 @@
 Variant Script for ignoring OWASP Benchmark pages that we don't want to attack.
 */
 
+const List = Java.type("java.util.List");
+
 function parseParameters(helper, msg) { }
 
 function setParameter(helper, msg, param, value, escaped) { }
@@ -39,11 +41,11 @@ function getTreePath(helper, msg) {
 	var uri = msg.getRequestHeader().getURI();
 	var path = uri.getPath()
 	if (/^\/benchmark\/cmdi-\d\d\/BenchmarkTest\d\d\d\d\d.html$/.test(path)) {
-		return []
+		return List.of();
 	}
 	var method = msg.getRequestHeader().getMethod()
 	if (method == "GET" && ignored_paths.indexOf(path) >= 0) {
-		return []
+		return List.of();
 	}
 	return null;
 }


### PR DESCRIPTION
Return a Java object instead to avoid concurrent accesses to the returned JS object.