### PR TITLE
Auth Tests Framework - Part 1

### DIFF
--- a/.github/workflows/auth-tests.yml
+++ b/.github/workflows/auth-tests.yml
@@ -1,0 +1,17 @@
+name: Run Auth Tests
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Authentication Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - 
+        name: Authentication plan tests
+        id: "test-auth-plans"
+        if: ${{ ! cancelled() }}
+        run: |
+          docker pull ghcr.io/zaproxy/zaproxy:nightly
+          docker run --rm -v $(pwd):/zap/wrk/:rw -t zaproxy/zap-nightly /zap/wrk/scans/auth/auth_plan_tests.sh

--- a/scans/auth/README.md
+++ b/scans/auth/README.md
@@ -1,0 +1,15 @@
+# Usage
+
+1. Clone the repo.
+1. Change directory into the repo.
+1. Pull the docker image if you want/need to update: `docker pull ghcr.io/zaproxy/zaproxy:nightly`
+1. Run the tests: `docker run --rm -v $(pwd):/zap/wrk/:rw -t zaproxy/zap-nightly /zap/wrk/scans/auth/auth_plan_tests.sh`
+
+
+1. To run a one-off: `zaproxy -cmd -autorun $PWD/scans/auth/plans_and_scripts/dev/csa.yaml`. (Where `dev` [the parent of the plans], is the "target".)
+
+## Types
+
+- bba - Browser Based Auth
+- bbaplus - Browser Based Auth with manual config or extra steps
+- csa - Client Script Auth

--- a/scans/auth/auth_plan_tests.sh
+++ b/scans/auth/auth_plan_tests.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Script for testing Automation Framework features
+
+RES=0
+
+mkdir -p /zap/wrk/output
+OUTPUT=/zap/wrk/output/output.yml
+# Remove output file in case it already exists
+rm -f $OUTPUT
+
+echo "Authentication tests"
+echo
+
+cd /zap/wrk/scans/auth/plans_and_scripts/
+
+summary="\nSummary:\n"
+INDENT="  "
+
+for TARGET in *
+do
+    if [ -d "$TARGET" ]
+    then
+        echo
+        cd "$TARGET"
+        echo "$TARGET:"|tee -a "$OUTPUT" > /dev/null
+        for file in *.yaml
+        do
+            echo "Target: $TARGET Plan: $file"
+            TYPE=$(echo "$file"|cut -d"." -f1)":"
+            echo -ne "$INDENT$TYPE"|tee -a "$OUTPUT" > /dev/null
+
+            /zap/zap.sh -cmd -autorun /zap/wrk/scans/auth/plans_and_scripts/"$TARGET"/"$file"
+            RET=$?
+
+            if [ "$RET" != 0 ] 
+            then
+                echo "ERROR"
+                echo " false"|tee -a "$OUTPUT" > /dev/null
+                summary="${summary}  Plan: $file\tERROR\n"
+                RES=1
+            else
+                echo "PASS"
+                echo " true"|tee -a "$OUTPUT" > /dev/null
+                summary="${summary}  Plan: $file\tPASS\n"
+            fi
+            sleep 2
+        done
+        if [ -f notes.txt ]
+        then
+            echo -ne "$INDENT"|tee -a "$OUTPUT" > /dev/null
+            echo -ne "note: "|tee -a "$OUTPUT" > /dev/null
+            echo \""$(cat notes.txt)"\"|tee -a "$OUTPUT" > /dev/null
+        fi
+        cd ..
+    fi
+done
+
+echo -e "$summary"
+echo "Exit Code: $RES"
+
+cat "$OUTPUT"
+
+exit $RES

--- a/scans/auth/plans_and_scripts/testfire/bba.yaml
+++ b/scans/auth/plans_and_scripts/testfire/bba.yaml
@@ -1,0 +1,32 @@
+env:
+  contexts:
+  - name: Authentication Test
+    urls:
+    - http://testfire.net
+    includePaths:
+    - https?://testfire.net.*
+    authentication:
+      method: browser
+      parameters:
+        loginPageUrl: http://testfire.net/login.jsp
+        loginPageWait: 2
+        browserId: firefox-headless
+      verification:
+        method: autodetect
+    sessionManagement:
+      method: autodetect
+    users:
+    - name: jsmith
+      credentials:
+        password: demo1234
+        username: jsmith
+jobs:
+- type: requestor
+  parameters:
+    user: jsmith
+  requests:
+  - name: Get Account Details
+    url: 'http://testfire.net/bank/showAccount?listAccounts=800002'
+    method: GET
+    responseCode: 200
+

--- a/scans/auth/plans_and_scripts/testfire/bbaplus.yaml
+++ b/scans/auth/plans_and_scripts/testfire/bbaplus.yaml
@@ -1,0 +1,46 @@
+env:
+  contexts:
+  - name: Authentication Test
+    urls:
+    - http://testfire.net
+    includePaths:
+    - https?://testfire.net.*
+    authentication:
+      method: browser
+      parameters:
+        loginPageUrl: http://testfire.net/login.jsp
+        loginPageWait: 2
+        browserId: firefox-headless
+        steps:
+        - description: Fill Username
+          type: USERNAME
+          cssSelector: "#uid"
+          value: jsmith
+          timeout: 1000
+      verification:
+        method: poll
+        loggedInRegex: \QCongratulations!\E
+        loggedOutRegex: \Q 403 Forbidden\E
+        pollFrequency: 60
+        pollUnits: seconds
+        pollUrl: http://testfire.net/bank/main.jsp
+        pollPostData: ""
+    sessionManagement:
+      method: headers
+      parameters:
+        Cookie: "JSESSIONID={%cookie:JSESSIONID%};"
+    users:
+    - name: jsmith
+      credentials:
+        password: demo1234
+        username: jsmith
+jobs:
+- type: requestor
+  parameters:
+    user: jsmith
+  requests:
+  - name: Get Account Details
+    url: 'http://testfire.net/bank/showAccount?listAccounts=800002'
+    method: GET
+    responseCode: 200
+

--- a/scans/auth/plans_and_scripts/testfire/csa.yaml
+++ b/scans/auth/plans_and_scripts/testfire/csa.yaml
@@ -1,0 +1,39 @@
+env:
+  contexts:
+  - name: Authentication Test
+    urls:
+    - http://testfire.net
+    includePaths:
+    - https?://testfire.net.*
+    authentication:
+      method: script
+      parameters:
+        script: ./testfire.zst
+        scriptEngine: Mozilla Zest
+      verification:
+        method: poll
+        loggedInRegex: \QCongratulations!\E
+        loggedOutRegex: \Q 403 Forbidden\E
+        pollFrequency: 60
+        pollUnits: seconds
+        pollUrl: http://testfire.net/bank/main.jsp
+        pollPostData: ""
+    sessionManagement:
+      method: headers
+      parameters:
+        Cookie: "JSESSIONID={%cookie:JSESSIONID%};"
+    users:
+    - name: jsmith
+      credentials:
+        Username: jsmith
+        Password: demo1234
+jobs:
+- type: requestor
+  parameters:
+    user: jsmith
+  requests:
+  - name: Get Account Details
+    url: 'http://testfire.net/bank/showAccount?listAccounts=800002'
+    method: GET
+    responseCode: 200
+

--- a/scans/auth/plans_and_scripts/testfire/notes.txt
+++ b/scans/auth/plans_and_scripts/testfire/notes.txt
@@ -1,0 +1,1 @@
+BBA is not currently working as it attempts to fill the first field which is not the username field.

--- a/scans/auth/plans_and_scripts/testfire/testfire.zst
+++ b/scans/auth/plans_and_scripts/testfire/testfire.zst
@@ -1,0 +1,80 @@
+{
+  "about": "This is a Zest script. For more details about Zest visit https://github.com/zaproxy/zest/",
+  "zestVersion": "0.3",
+  "title": "testfire.zst",
+  "description": "",
+  "prefix": "",
+  "type": "StandAlone",
+  "parameters": {
+    "tokenStart": "{{",
+    "tokenEnd": "}}",
+    "tokens": {},
+    "elementType": "ZestVariables"
+  },
+  "statements": [
+    {
+      "windowHandle": "windowHandle1",
+      "browserType": "firefox",
+      "url": "http://testfire.net/login.jsp",
+      "capabilities": "",
+      "headless": true,
+      "index": 1,
+      "enabled": true,
+      "elementType": "ZestClientLaunch"
+    },
+    {
+      "windowHandle": "windowHandle1",
+      "type": "id",
+      "element": "uid",
+      "index": 2,
+      "enabled": true,
+      "elementType": "ZestClientElementClear"
+    },
+    {
+      "value": "jsmith",
+      "windowHandle": "windowHandle1",
+      "type": "id",
+      "element": "uid",
+      "index": 3,
+      "enabled": true,
+      "elementType": "ZestClientElementSendKeys"
+    },
+    {
+      "windowHandle": "windowHandle1",
+      "type": "id",
+      "element": "passw",
+      "index": 4,
+      "enabled": true,
+      "elementType": "ZestClientElementClear"
+    },
+    {
+      "value": "demo1234",
+      "windowHandle": "windowHandle1",
+      "type": "id",
+      "element": "passw",
+      "index": 5,
+      "enabled": true,
+      "elementType": "ZestClientElementSendKeys"
+    },
+    {
+      "windowHandle": "windowHandle1",
+      "type": "id",
+      "element": "passw",
+      "index": 6,
+      "enabled": true,
+      "elementType": "ZestClientElementSubmit"
+    },
+    {
+      "windowHandle": "windowHandle1",
+      "type": "xpath",
+      "element": "/html/body/table/tbody/tr[2]/td[2]/div/form/table/tbody/tr[3]/td[2]/input",
+      "index": 7,
+      "enabled": true,
+      "elementType": "ZestClientElementClick"
+    }
+  ],
+  "authentication": [],
+  "index": 0,
+  "enabled": true,
+  "elementType": "ZestScript"
+}


### PR DESCRIPTION
Adds a github workflow to get the nightly docker images, then maps a drive and runs the identified automation framework plans. (This initial plan/script just use the dev add-on).

Next part will be to generate a data file from the results (YAML/JSON), and PR it to zaproxy-website?
Third part will be to create the page/handling on the website.

--- 

Maybe there should be another layer here? 🤷‍♂️

```
└───plans_and_scripts
        dev_bba.yaml
        dev_csa.yaml
        dev_csa.zst
```

```
└───plans_and_scripts
        └───dev
                dev_bba.yaml
                dev_csa.yaml
                dev_csa.zst
        └───juiceshop
                *.yaml
                *.zst
        └───testfire
                *.yaml
                *.zst
```