### PR TITLE
Switch to autodetect for auth tests & tweak readme

### DIFF
--- a/scans/auth/README.md
+++ b/scans/auth/README.md
@@ -5,8 +5,9 @@
 1. Pull the docker image if you want/need to update: `docker pull ghcr.io/zaproxy/zaproxy:nightly`
 1. Run the tests: `docker run --rm -v $(pwd):/zap/wrk/:rw -t zaproxy/zap-nightly /zap/wrk/scans/auth/auth_plan_tests.sh`
 
+---
 
-1. To run a one-off: `zaproxy -cmd -autorun $PWD/scans/auth/plans_and_scripts/dev/csa.yaml`. (Where `dev` [the parent of the plans], is the "target".)
+1. To run a one-off: `zaproxy -cmd -autorun $PWD/scans/auth/plans_and_scripts/testfire/csa.yaml`. (Where `testfire` [the parent of the plans], is the "target".)
 
 ## Types
 

--- a/scans/auth/plans_and_scripts/testfire/bbaplus.yaml
+++ b/scans/auth/plans_and_scripts/testfire/bbaplus.yaml
@@ -18,17 +18,9 @@ env:
           value: jsmith
           timeout: 1000
       verification:
-        method: poll
-        loggedInRegex: \QCongratulations!\E
-        loggedOutRegex: \Q 403 Forbidden\E
-        pollFrequency: 60
-        pollUnits: seconds
-        pollUrl: http://testfire.net/bank/main.jsp
-        pollPostData: ""
+        method: autodetect
     sessionManagement:
-      method: headers
-      parameters:
-        Cookie: "JSESSIONID={%cookie:JSESSIONID%};"
+      method: autodetect
     users:
     - name: jsmith
       credentials:

--- a/scans/auth/plans_and_scripts/testfire/csa.yaml
+++ b/scans/auth/plans_and_scripts/testfire/csa.yaml
@@ -11,17 +11,9 @@ env:
         script: ./testfire.zst
         scriptEngine: Mozilla Zest
       verification:
-        method: poll
-        loggedInRegex: \QCongratulations!\E
-        loggedOutRegex: \Q 403 Forbidden\E
-        pollFrequency: 60
-        pollUnits: seconds
-        pollUrl: http://testfire.net/bank/main.jsp
-        pollPostData: ""
+        method: autodetect
     sessionManagement:
-      method: headers
-      parameters:
-        Cookie: "JSESSIONID={%cookie:JSESSIONID%};"
+      method: autodetect
     users:
     - name: jsmith
       credentials:

--- a/scans/auth/plans_and_scripts/testfire/notes.txt
+++ b/scans/auth/plans_and_scripts/testfire/notes.txt
@@ -1,1 +1,1 @@
-BBA is not currently working as it attempts to fill the first field which is not the username field.
+BBA is not currently working as it attempts to fill the first field which is not the username field. CSA is failing due to use of autodetect.


### PR DESCRIPTION
- Adjust README to have an HR and restart the numbered items.
- Adjust testfire/bbaplus to use autodetect for verification and session mgmt.
- Adjust testfire/csa to use autodetect for verification and session mgmt.

```console
Summary:
  Plan: bba.yaml        ERROR
  Plan: bbaplus.yaml    PASS
  Plan: csa.yaml        ERROR

Exit Code: 1
testfire:
  bba: false
  bbaplus: true
  csa: false
  note: "BBA is not currently working as it attempts to fill the first field which is not the username field."
```