### PR TITLE
auth tests: allow BBA plan to use envvars

### DIFF
--- a/.github/workflows/auth-tests.yml
+++ b/.github/workflows/auth-tests.yml
@@ -8,10 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - 
-        name: Authentication plan tests
+      - name: Authentication plan tests
         id: "test-auth-plans"
         if: ${{ ! cancelled() }}
+	env:
+          AUTH_SCANS_CREDS: ${{ secrets.AUTH_SCANS_CREDS }}
         run: |
           docker pull ghcr.io/zaproxy/zaproxy:nightly
-          docker run --rm -v $(pwd):/zap/wrk/:rw -t zaproxy/zap-nightly /zap/wrk/scans/auth/auth_plan_tests.sh
+          echo "$AUTH_SCANS_CREDS" | tee -a scans/auth/all_vars.env > /dev/null
+          docker run --rm -v $(pwd):/zap/wrk/:rw --env-file scans/auth/all_vars.env -t zaproxy/zap-nightly /zap/wrk/scans/auth/auth_plan_tests.sh 

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 # Workflows & scans
 # ------------------
 */output
+scans/auth/all_vars.env

--- a/scans/auth/README.md
+++ b/scans/auth/README.md
@@ -3,14 +3,19 @@
 1. Clone the repo.
 1. Change directory into the repo.
 1. Pull the docker image if you want/need to update: `docker pull ghcr.io/zaproxy/zaproxy:nightly`
-1. Run the tests: `docker run --rm -v $(pwd):/zap/wrk/:rw -t zaproxy/zap-nightly /zap/wrk/scans/auth/auth_plan_tests.sh`
+1. Create `scans/auth/all_vars.env` with standard `key=value` pairs. Keys should be `<target><user_or_pass>=value`, ex: `foo_user=jsmith`, `foo_pass=demo1234` (assuming a target known as `foo`).
+1. Run the tests: `docker run --rm -v $(pwd):/zap/wrk/:rw --env-file scans/auth/all_vars.env -t zaproxy/zap-nightly /zap/wrk/scans/auth/auth_plan_tests.sh`
 
----
-
-1. To run a one-off: `zaproxy -cmd -autorun $PWD/scans/auth/plans_and_scripts/testfire/csa.yaml`. (Where `testfire` [the parent of the plans], is the "target".)
 
 ## Types
 
 - bba - Browser Based Auth
 - bbaplus - Browser Based Auth with manual config or extra steps
 - csa - Client Script Auth
+
+> [!IMPORTANT]
+> If `output.yml` does not contain a result for a given Type, then that type is unnecessary because easier options exist. Ex: If BBA works there likely won't be a bbaplus/csa plan nor result.
+
+# One-offs
+
+1. To run a one-off: `docker run --rm -v $(pwd):/zap/wrk/:rw --env-file scans/auth/all_vars.env -t zaproxy/zap-nightly /zap/zap.sh -cmd -autorun /zap/wrk/scans/auth/plans_and_scripts/testfire/bba.yaml`.

--- a/scans/auth/auth_plan_tests.sh
+++ b/scans/auth/auth_plan_tests.sh
@@ -13,13 +13,14 @@ echo
 
 cd /zap/wrk/scans/auth/plans_and_scripts/
 
-summary="\nSummary:\n"
+summary="\n\nSummary:\n========\n"
 INDENT="  "
 
 for TARGET in *
 do
     if [ -d "$TARGET" ]
     then
+        summary="${summary}$TARGET\n"
         echo
         cd "$TARGET"
         echo "$TARGET:"|tee -a "$OUTPUT" > /dev/null

--- a/scans/auth/plans_and_scripts/testfire/bba.yaml
+++ b/scans/auth/plans_and_scripts/testfire/bba.yaml
@@ -4,7 +4,7 @@ env:
     urls:
     - http://testfire.net
     includePaths:
-    - https?://testfire.net.*
+    - http://testfire.net.*
     authentication:
       method: browser
       parameters:
@@ -16,14 +16,14 @@ env:
     sessionManagement:
       method: autodetect
     users:
-    - name: jsmith
+    - name: testuser
       credentials:
-        password: demo1234
-        username: jsmith
+        password: ${testfire_pass}
+        username: ${testfire_user}
 jobs:
 - type: requestor
   parameters:
-    user: jsmith
+    user: testuser
   requests:
   - name: Get Account Details
     url: 'http://testfire.net/bank/showAccount?listAccounts=800002'

--- a/scans/auth/plans_and_scripts/testfire/bbaplus.yaml
+++ b/scans/auth/plans_and_scripts/testfire/bbaplus.yaml
@@ -24,7 +24,7 @@ env:
     users:
     - name: testuser
       credentials:
-        password: ${testfire_pas}
+        password: ${testfire_pass}
         username: ${testfire_user}
 jobs:
 - type: requestor

--- a/scans/auth/plans_and_scripts/testfire/csa.yaml
+++ b/scans/auth/plans_and_scripts/testfire/csa.yaml
@@ -15,14 +15,14 @@ env:
     sessionManagement:
       method: autodetect
     users:
-    - name: jsmith
+    - name: testuser
       credentials:
-        Username: jsmith
-        Password: demo1234
+        Username: ${testfire_user}
+        Password: ${testfire_pass}
 jobs:
 - type: requestor
   parameters:
-    user: jsmith
+    user: testuser
   requests:
   - name: Get Account Details
     url: 'http://testfire.net/bank/showAccount?listAccounts=800002'

--- a/scans/auth/plans_and_scripts/testphp/bba.yaml
+++ b/scans/auth/plans_and_scripts/testphp/bba.yaml
@@ -2,21 +2,15 @@ env:
   contexts:
   - name: Authentication Test
     urls:
-    - http://testfire.net
+    - http://testphp.vulnweb.com
     includePaths:
-    - https?://testfire.net.*
+    - http://testphp.vulnweb.com.*
     authentication:
       method: browser
       parameters:
-        loginPageUrl: http://testfire.net/login.jsp
+        loginPageUrl: http://testphp.vulnweb.com/login.php
         loginPageWait: 2
         browserId: firefox-headless
-        steps:
-        - description: Fill Username
-          type: USERNAME
-          cssSelector: "#uid"
-          value: jsmith
-          timeout: 1000
       verification:
         method: autodetect
     sessionManagement:
@@ -24,15 +18,15 @@ env:
     users:
     - name: testuser
       credentials:
-        password: ${testfire_pas}
-        username: ${testfire_user}
+        password: ${testphp_pass}
+        username: ${testphp_user}
 jobs:
 - type: requestor
   parameters:
     user: testuser
   requests:
   - name: Get Account Details
-    url: 'http://testfire.net/bank/showAccount?listAccounts=800002'
+    url: 'http://testphp.vulnweb.com/userinfo.php'
     method: GET
     responseCode: 200
 


### PR DESCRIPTION
- Updated README with details with regard to using plans with envvars.
-  Updated test execution script to set vars specific to the target. 
- Update BBA plan to rely extensively on envvars. 
- On all three test plans change to a generic internal username.
- Add vars file for testfire BBA.
- Add testphp bba using secrets.