### PR TITLE
auth tests: Use report for further details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@
 
 # Workflows & scans
 # ------------------
-*/output
+output/
 scans/auth/all_vars.env

--- a/scans/auth/README.md
+++ b/scans/auth/README.md
@@ -9,7 +9,7 @@
 
 ## Types
 
-- bba - Browser Based Auth
+- stdbba - Browser Based Auth
 - bbaplus - Browser Based Auth with manual config or extra steps
 - csa - Client Script Auth
 
@@ -18,4 +18,4 @@
 
 # One-offs
 
-1. To run a one-off: `docker run --rm -v $(pwd):/zap/wrk/:rw --env-file scans/auth/all_vars.env -t zaproxy/zap-nightly /zap/zap.sh -cmd -autorun /zap/wrk/scans/auth/plans_and_scripts/testfire/bba.yaml`.
+1. To run a one-off: `docker run --rm -v $(pwd):/zap/wrk/:rw --env-file scans/auth/all_vars.env -t zaproxy/zap-nightly /zap/zap.sh -cmd -autorun /zap/wrk/scans/auth/plans_and_scripts/testfire/bbaplus.yaml`.

--- a/scans/auth/auth_plan_tests.sh
+++ b/scans/auth/auth_plan_tests.sh
@@ -7,12 +7,17 @@ runplan()
     FILE=$2
     TYPE=$3
     echo "Target: $TARGET Plan: $FILE"
-    echo -ne "$INDENT$TYPE"|tee -a "$OUTPUT" > /dev/null
+    echo -ne "$INDENT"- type: "$TYPE\n"|tee -a "$OUTPUT" > /dev/null
+    echo -ne "$INDENT$INDENT"auth:|tee -a "$OUTPUT" > /dev/null
 
     /zap/zap.sh -cmd -autorun "$FILE"
     RET=$?
-    AUTHREPORT=../../auth-report.json
-
+    if [[ $TYPE == "stdbba" ]]
+    then
+        AUTHREPORT=../../auth-report.json
+    else
+        AUTHREPORT=auth-report.json
+    fi
     if [ -f $AUTHREPORT ]
     then
         echo "Using data from the authentication report"
@@ -23,6 +28,7 @@ runplan()
             echo "PASS"
             echo " true"|tee -a "$OUTPUT" > /dev/null
             summary="${summary}  Plan: $TYPE\tPASS\n"
+            getreportdetails $AUTHREPORT
         else
             if [ "$AUTH" != "false" ]
             then
@@ -31,6 +37,7 @@ runplan()
             echo "ERROR"
             echo " false"|tee -a "$OUTPUT" > /dev/null
             summary="${summary}  Plan: $TYPE\tERROR\n"
+            getreportdetails $AUTHREPORT
             RES=1
         fi 
         rm $AUTHREPORT
@@ -48,6 +55,19 @@ runplan()
             summary="${summary}  Plan: $TYPE\tPASS\n"
         fi
     fi
+}
+
+getreportdetails()
+{
+    AUTHREPORT=$1
+    USER_SUCCESS=`jq -r '.summaryItems[] | select(.key == "auth.summary.username") | .passed' $AUTHREPORT`
+    echo "$INDENT$INDENT"username: $USER_SUCCESS|tee -a "$OUTPUT" > /dev/null
+    PASS_SUCCESS=`jq -r '.summaryItems[] | select(.key == "auth.summary.password") | .passed' $AUTHREPORT`
+    echo "$INDENT$INDENT"password: $PASS_SUCCESS|tee -a "$OUTPUT" > /dev/null
+    SESS_SUCCESS=`jq -r '.summaryItems[] | select(.key == "auth.summary.session") | .passed' $AUTHREPORT`
+    echo "$INDENT$INDENT"session: $SESS_SUCCESS|tee -a "$OUTPUT" > /dev/null
+    VERIF_SUCCESS=`jq -r '.summaryItems[] | select(.key == "auth.summary.verif") | .passed' $AUTHREPORT`
+    echo "$INDENT$INDENT"verification: $VERIF_SUCCESS|tee -a "$OUTPUT" > /dev/null
 }
 
 RES=0
@@ -85,7 +105,7 @@ do
             export username=$(eval echo \$\{TARGET\}_user)
             export zapusername=${!username}
             
-            runplan $TARGET /zap/wrk/scans/auth/bba-auth-test.yaml "stdbba:"
+            runplan $TARGET /zap/wrk/scans/auth/bba-auth-test.yaml "stdbba"
         else
             echo "No $TARGET/config file"
         fi
@@ -93,7 +113,7 @@ do
         shopt -s nullglob  # May be no yaml files
         for file in *.yaml
         do
-            runplan $TARGET /zap/wrk/scans/auth/plans_and_scripts/$TARGET/$file $(echo "$file"|cut -d"." -f1)":"
+            runplan $TARGET /zap/wrk/scans/auth/plans_and_scripts/$TARGET/$file $(echo "$file"|cut -d"." -f1)
             sleep 2
         done
         shopt -u nullglob
@@ -101,8 +121,8 @@ do
         if [ -f notes.txt ]
         then
             echo -ne "$INDENT"|tee -a "$OUTPUT" > /dev/null
-            echo -ne "note: "|tee -a "$OUTPUT" > /dev/null
-            echo \""$(cat notes.txt)"\"|tee -a "$OUTPUT" > /dev/null
+            echo -ne "- note: "|tee -a "$OUTPUT" > /dev/null
+            echo "\"$(cat notes.txt)\""|tee -a "$OUTPUT" > /dev/null
         fi
         cd ..
     fi

--- a/scans/auth/plans_and_scripts/testfire/bbaplus.yaml
+++ b/scans/auth/plans_and_scripts/testfire/bbaplus.yaml
@@ -27,12 +27,35 @@ env:
         password: ${testfire_pass}
         username: ${testfire_user}
 jobs:
+- type: passiveScan-config
+  parameters:
+    disableAllRules: true
+  rules:
+  - name: Authentication Request Identified
+    id: 10111
+    threshold: medium
+  - name: Session Management Response Identified
+    id: 10112
+    threshold: medium
+  - name: Verification Request Identified
+    id: 10113
+    threshold: medium
 - type: requestor
   parameters:
     user: testuser
   requests:
-  - name: Get Account Details
-    url: 'http://testfire.net/bank/showAccount?listAccounts=800002'
-    method: GET
-    responseCode: 200
-
+  - url: http://testfire.net
+- type: passiveScan-wait
+  parameters: {}
+- name: auth-test-report
+  type: report
+  parameters:
+    template: auth-report-json
+    theme: null
+    reportDir: .
+    reportFile: auth-report.json
+    reportTitle: ZAP by Checkmarx Scanning Report
+  sections:
+  - summary
+  - afenv
+  - statistics

--- a/scans/auth/plans_and_scripts/testfire/csa.yaml
+++ b/scans/auth/plans_and_scripts/testfire/csa.yaml
@@ -20,12 +20,35 @@ env:
         Username: ${testfire_user}
         Password: ${testfire_pass}
 jobs:
+- type: passiveScan-config
+  parameters:
+    disableAllRules: true
+  rules:
+  - name: Authentication Request Identified
+    id: 10111
+    threshold: medium
+  - name: Session Management Response Identified
+    id: 10112
+    threshold: medium
+  - name: Verification Request Identified
+    id: 10113
+    threshold: medium
 - type: requestor
   parameters:
     user: testuser
   requests:
-  - name: Get Account Details
-    url: 'http://testfire.net/bank/showAccount?listAccounts=800002'
-    method: GET
-    responseCode: 200
-
+  - url: http://testfire.net
+- type: passiveScan-wait
+  parameters: {}
+- name: auth-test-report
+  type: report
+  parameters:
+    template: auth-report-json
+    theme: null
+    reportDir: .
+    reportFile: auth-report.json
+    reportTitle: ZAP by Checkmarx Scanning Report
+  sections:
+  - summary
+  - afenv
+  - statistics


### PR DESCRIPTION
- Properly ignore the output directory.
- Tweak README.
- Update script with further parsing and fixes.
- Update testfire bbaplus and csa to use a report job.

<details>
<summary>Output sample</summary>

```
Summary:
========
aspnet
  Plan: stdbba  PASS
ginnjuice
  Plan: stdbba  ERROR
testasp
  Plan: stdbba  PASS
testfire
  Plan: stdbba  PASS
  Plan: bbaplus PASS
  Plan: csa     ERROR
testhtml5
  Plan: stdbba  ERROR
testphp
  Plan: stdbba  PASS
webappsec
  Plan: stdbba  ERROR

aspnet:
  stdbba: true
    username: true
    passwrod: true
    session: true
    verification: true
 true
ginnjuice:
  stdbba: false
    username: false
    passwrod: false
    session: true
    verification: false
testasp:
  stdbba: true
    username: true
    passwrod: true
    session: true
    verification: true
testfire:
  stdbba: true
    username: true
    passwrod: true
    session: true
    verification: true
  bbaplus: true
    username: true
    passwrod: true
    session: true
    verification: true
  csa: false
    username:
    passwrod:
    session: false
    verification: false
  note: "CSA is failing due to use of autodetect."
testhtml5:
  stdbba: false
    username: false
    passwrod: true
    session: false
    verification: false
testphp:
  stdbba: true
    username: true
    passwrod: true
    session: true
    verification: true
  note: ""
webappsec:
  stdbba: false
    username: true
    passwrod: true
    session: false
    verification: false

```

</details>