### PR TITLE
auth tests: get the site from the report for output

### DIFF
--- a/.github/workflows/auth-tests.yml
+++ b/.github/workflows/auth-tests.yml
@@ -7,14 +7,16 @@ jobs:
     name: Authentication Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Pull nightly image
+        run: docker pull ghcr.io/zaproxy/zaproxy:nightly
       - name: Authentication plan tests
         id: "test-auth-plans"
         if: ${{ ! cancelled() }}
         env:
           AUTH_SCANS_CREDS: ${{ secrets.AUTH_SCANS_CREDS }}
         run: |
-          docker pull ghcr.io/zaproxy/zaproxy:nightly
           echo "$AUTH_SCANS_CREDS" | tee -a scans/auth/all_vars.env > /dev/null
           chmod -R a+w $(pwd)
           docker run --rm -v $(pwd):/zap/wrk/:rw --env-file scans/auth/all_vars.env -t zaproxy/zap-nightly /zap/wrk/scans/auth/auth_plan_tests.sh 

--- a/scans/auth/auth_plan_tests.sh
+++ b/scans/auth/auth_plan_tests.sh
@@ -7,8 +7,8 @@ runplan()
     FILE=$2
     TYPE=$3
     echo "Target: $TARGET Plan: $FILE"
-    echo -ne "$INDENT"- type: "$TYPE\n"|tee -a "$OUTPUT" > /dev/null
-    echo -ne "$INDENT$INDENT"auth:|tee -a "$OUTPUT" > /dev/null
+    echo -ne "$INDENT$INDENT$TYPE:\n"|tee -a "$OUTPUT" > /dev/null
+    echo -ne "$INDENT$INDENT$INDENT"auth:|tee -a "$OUTPUT" > /dev/null
 
     /zap/zap.sh -cmd -autorun "$FILE"
     RET=$?
@@ -61,13 +61,13 @@ getreportdetails()
 {
     AUTHREPORT=$1
     USER_SUCCESS=`jq -r '.summaryItems[] | select(.key == "auth.summary.username") | .passed' $AUTHREPORT`
-    echo "$INDENT$INDENT"username: $USER_SUCCESS|tee -a "$OUTPUT" > /dev/null
+    echo "$INDENT$INDENT$INDENT"username: $USER_SUCCESS|tee -a "$OUTPUT" > /dev/null
     PASS_SUCCESS=`jq -r '.summaryItems[] | select(.key == "auth.summary.password") | .passed' $AUTHREPORT`
-    echo "$INDENT$INDENT"password: $PASS_SUCCESS|tee -a "$OUTPUT" > /dev/null
+    echo "$INDENT$INDENT$INDENT"password: $PASS_SUCCESS|tee -a "$OUTPUT" > /dev/null
     SESS_SUCCESS=`jq -r '.summaryItems[] | select(.key == "auth.summary.session") | .passed' $AUTHREPORT`
-    echo "$INDENT$INDENT"session: $SESS_SUCCESS|tee -a "$OUTPUT" > /dev/null
+    echo "$INDENT$INDENT$INDENT"session: $SESS_SUCCESS|tee -a "$OUTPUT" > /dev/null
     VERIF_SUCCESS=`jq -r '.summaryItems[] | select(.key == "auth.summary.verif") | .passed' $AUTHREPORT`
-    echo "$INDENT$INDENT"verification: $VERIF_SUCCESS|tee -a "$OUTPUT" > /dev/null
+    echo "$INDENT$INDENT$INDENT"verification: $VERIF_SUCCESS|tee -a "$OUTPUT" > /dev/null
 }
 
 RES=0
@@ -104,12 +104,24 @@ do
 
             export username=$(eval echo \$\{TARGET\}_user)
             export zapusername=${!username}
-            
+
+            echo -ne "$INDENT"|tee -a "$OUTPUT" > /dev/null
+            echo -ne "site: \"$zapsite\"\n"|tee -a "$OUTPUT" > /dev/null
+
+            if [ -f notes.txt ]
+            then
+                echo -ne "$INDENT"|tee -a "$OUTPUT" > /dev/null
+                echo -ne "note: "|tee -a "$OUTPUT" > /dev/null
+                echo "\"$(cat notes.txt)\""|tee -a "$OUTPUT" > /dev/null
+            fi
+
+            echo -ne "$INDENT"|tee -a "$OUTPUT" > /dev/null
+            echo -ne "plans:\n"|tee -a "$OUTPUT" > /dev/null
             runplan $TARGET /zap/wrk/scans/auth/bba-auth-test.yaml "stdbba"
         else
             echo "No $TARGET/config file"
         fi
-        
+
         shopt -s nullglob  # May be no yaml files
         for file in *.yaml
         do
@@ -118,12 +130,6 @@ do
         done
         shopt -u nullglob
 
-        if [ -f notes.txt ]
-        then
-            echo -ne "$INDENT"|tee -a "$OUTPUT" > /dev/null
-            echo -ne "- note: "|tee -a "$OUTPUT" > /dev/null
-            echo "\"$(cat notes.txt)\""|tee -a "$OUTPUT" > /dev/null
-        fi
         cd ..
     fi
 done

--- a/scans/auth/plans_and_scripts/testfire/bbaplus.yaml
+++ b/scans/auth/plans_and_scripts/testfire/bbaplus.yaml
@@ -2,13 +2,13 @@ env:
   contexts:
   - name: Authentication Test
     urls:
-    - http://testfire.net
+    - ${zapsite}
     includePaths:
-    - https?://testfire.net.*
+    - ${zapsite}.*
     authentication:
       method: browser
       parameters:
-        loginPageUrl: http://testfire.net/login.jsp
+        loginPageUrl: ${zaploginurl}
         loginPageWait: 2
         browserId: firefox-headless
         steps:
@@ -24,8 +24,8 @@ env:
     users:
     - name: testuser
       credentials:
-        password: ${testfire_pass}
-        username: ${testfire_user}
+        username: ${zapusername}
+        password: ${zappassword}
 jobs:
 - type: passiveScan-config
   parameters:
@@ -44,7 +44,7 @@ jobs:
   parameters:
     user: testuser
   requests:
-  - url: http://testfire.net
+  - url: ${zapsite}
 - type: passiveScan-wait
   parameters: {}
 - name: auth-test-report

--- a/scans/auth/plans_and_scripts/testfire/csa.yaml
+++ b/scans/auth/plans_and_scripts/testfire/csa.yaml
@@ -2,9 +2,9 @@ env:
   contexts:
   - name: Authentication Test
     urls:
-    - http://testfire.net
+    - ${zapsite}
     includePaths:
-    - https?://testfire.net.*
+    - ${zapsite}.*
     authentication:
       method: script
       parameters:
@@ -17,8 +17,8 @@ env:
     users:
     - name: testuser
       credentials:
-        Username: ${testfire_user}
-        Password: ${testfire_pass}
+        Username: ${zapusername}
+        Password: ${zappassword}
 jobs:
 - type: passiveScan-config
   parameters:
@@ -37,7 +37,7 @@ jobs:
   parameters:
     user: testuser
   requests:
-  - url: http://testfire.net
+  - url: ${zapsite}
 - type: passiveScan-wait
   parameters: {}
 - name: auth-test-report


### PR DESCRIPTION
- Workflow changed to more discrete steps so that output is more focused
- auth_plan_tests.sh > Adjusted output.
- testfire plans > Adapted to use env vars.

Sample

```yaml
testfire:
  site: "http://testfire.net"
  note: "CSA is failing due to use of autodetect."
  plans:
    stdbba:
      auth: true
      username: true
      password: true
      session: true
      verification: true
    bbaplus:
      auth: true
      username: true
      password: true
      session: true
      verification: true
    csa:S
      username:
      password:
      session: false
      verification: false
testphp:
  site: "http://testphp.vulnweb.com"
  note: ""
  plans:
    stdbba:
      auth: true
      username: true
      password: true
      session: true
      verification: true

```