### PR TITLE
auth tests: Set upstream branch earlier

### DIFF
--- a/.github/workflows/auth-tests.yml
+++ b/.github/workflows/auth-tests.yml
@@ -53,6 +53,7 @@ jobs:
           git update-index -q --refresh
           ## If there are changes: comment, commit, PR
           if ! git diff-index --quiet HEAD --; then
+            git branch --set-upstream-to=origin/$BRANCH
             gh repo set-default zaproxy/zaproxy-website
             if $(gh pr view); then
               # There's already a PR so commit and update it
@@ -62,7 +63,7 @@ jobs:
               git remote set-url origin https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$GITHUB_USER/zaproxy-website.git
               git add .
               git commit -m "Authentication Tests Update" --signoff
-              git push --set-upstream origin $BRANCH --force
+              git push --force
               # Open the PR
               gh pr create -f
             fi


### PR DESCRIPTION
Hopefully this will address github cli's inability to identify existing PRs (if any).
https://github.com/zapbot/zap-mgmt-scripts/actions/runs/13682213589/job/38257122774

Refs:
- https://github.com/cli/cli/issues/888
- https://github.com/cli/cli/issues/7590
- https://stackoverflow.com/questions/520650/make-an-existing-git-branch-track-a-remote-branch