### PR TITLE
auth tests: Actually skip if marked disabled

### DIFF
--- a/scans/auth/auth_plan_tests.sh
+++ b/scans/auth/auth_plan_tests.sh
@@ -89,6 +89,11 @@ for TARGET in *
 do
     if [ -d "$TARGET" ]
     then
+        if [ -f "config.disabled" ]
+        then
+            echo "Skipping $TARGET it has been disabled"
+            continue
+        fi
         summary="${summary}$TARGET\n"
         echo
         cd "$TARGET"


### PR DESCRIPTION
Previously the skip assumed the config simply wasn't found and that meant other plans (yaml) likely didn't exist. Now specifically checks if `config.disabled` exists and skips to next target.