### PR TITLE
Removing deleted SSP Docker repos

### DIFF
--- a/stats/docker.py
+++ b/stats/docker.py
@@ -13,8 +13,6 @@ urls = {
     "ssp-nightly": "https://registry.hub.docker.com/v2/repositories/softwaresecurityproject/zap-nightly/",
     "ssp-bare": "https://registry.hub.docker.com/v2/repositories/softwaresecurityproject/zap-bare/",
     "zaproxy-stable": "https://registry.hub.docker.com/v2/repositories/zaproxy/zap-stable/",
-    "zaproxy-weekly": "https://registry.hub.docker.com/v2/repositories/zaproxy/zap-weekly/",
-    "zaproxy-nightly": "https://registry.hub.docker.com/v2/repositories/zaproxy/zap-nightly/",
     "zaproxy-bare": "https://registry.hub.docker.com/v2/repositories/zaproxy/zap-bare/",
     }
 


### PR DESCRIPTION
The scripts are currently failing...
https://github.com/zapbot/zap-mgmt-scripts/actions/runs/16584146633/job/46925226394