### PR TITLE
Wavsep scans - remove docker `-it` flags

### DIFF
--- a/.github/workflows/zap-vs-wavsep.yml
+++ b/.github/workflows/zap-vs-wavsep.yml
@@ -33,13 +33,13 @@ jobs:
     - name: Scan Wavsep
       run: |
         # start Wavsep
-        docker run --rm -it -p 8080:8080 -p 3306:3306 zaproxy/wavsep
+        docker run --rm -p 8080:8080 -p 3306:3306 zaproxy/wavsep
         
         cd zap-mgmt-scripts/scans/wavsep
         # Need to do this so the zap user in docker can write to the directory
         mkdir res
         chmod a+w res
-        docker run -v $(pwd):/zap/wrk/:rw --network host -t ghcr.io/zaproxy/zaproxy:nightly zap.sh -cmd -silent -autorun /zap/wrk/wavsep.yaml
+        docker run -v $(pwd):/zap/wrk/:rw --network host ghcr.io/zaproxy/zaproxy:nightly zap.sh -cmd -silent -autorun /zap/wrk/wavsep.yaml
         cp res/*.yml ../../../zaproxy-website/site/data/scans/wavsep/
 
     - name: Raise a PR on the website


### PR DESCRIPTION
Run failed with:
```
the input device is not a TTY
Error: Process completed with exit code 1.
```
Removing the docker `-it` flags, even though they seem to work in other actions 